### PR TITLE
Fix favicon/read method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ class DOStore extends BaseStore {
 
     return new Promise((resolve, reject) => {
       // remove trailing slashes
-      let path = (options.spaceUrl || '').replace(/\/$|\\$/, '')
+      let path = (options.path || '').replace(/\/$|\\$/, '')
 
       // check if path is stored in digitalocean handled by us
       if (!path.startsWith(this.spaceUrl)) {

--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ class DOStore extends BaseStore {
 
       // check if path is stored in digitalocean handled by us
       if (!path.startsWith(this.spaceUrl)) {
-        reject(new Error(`${path} is not stored in digital ocean`))
+        return reject(new Error(`${path} is not stored in digital ocean`))
       }
 
       path = path.substring(this.spaceUrl.length)


### PR DESCRIPTION
Hi @shiva-hack, thanks for writing this module! It works great for me except for the favicon. It seems like this is due to the `read` method. `options.spaceUrl` is undefined. The only property on `options` seems to be `path` which is what I'm guessing you meant to use. :) 

Also I added a return when rejecting the promise to avoid an unnecessary call to the DigitalOcean API.